### PR TITLE
Start a Tool Install Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Engineering
 This repository contains documentation managed by the ENF Engineering team. The documentation is primary focused on development processes followed by and tooling used by our team, which may be valuable to outside contributors who wish to contribute to the codebases managed by the ENF.
 
+If you are new here, start with the [computer setup guide](./computer-setup.md), then the [tool install guide](./tool-install-guide.md).
+
 ### Index
 1. [Process](./process/) - development processes
 1. [Tooling](./tooling/) - cheat sheets, links, procedures, and reference documents related to external tooling we use

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -1,6 +1,8 @@
 # Engineering Tooling
 Cheat sheets, links, procedures, and reference documents related to external tooling EOS Network Foundation developers and engineers use. For internal, in-house, or custom tooling, documentation should live in the repository with the tool source code and can be linked to from this `README.md`.
 
+If you are new here, start with the [computer setup guide](./computer-setup.md), then the [tool install guide](./tool-install-guide.md).
+
 ### Index
 - [Computer Setup](./computer-setup.md) - options for keeping your work and personal life separate on your computer
 - [Docker](./docker.md) - docker reference and quick-start guide

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -4,4 +4,5 @@ Cheat sheets, links, procedures, and reference documents related to external too
 ### Index
 - [Computer Setup](./computer-setup.md) - options for keeping your work and personal life separate on your computer
 - [Docker](./docker.md) - docker reference and quick-start guide
+- [Tool Install Guilde](./tool-install-guide.md) - install common tooling on your machine
 - [Ubuntu Virtual Machine Setup Guide](./vm-setup.md) - setup an Ubuntu virtual machine you can use for testing, and quickly restore to known-good states

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -2,5 +2,6 @@
 Cheat sheets, links, procedures, and reference documents related to external tooling EOS Network Foundation developers and engineers use. For internal, in-house, or custom tooling, documentation should live in the repository with the tool source code and can be linked to from this `README.md`.
 
 ### Index
+- [Computer Setup](./computer-setup.md) - options for keeping your work and personal life separate on your computer
 - [Docker](./docker.md) - docker reference and quick-start guide
 - [Ubuntu Virtual Machine Setup Guide](./vm-setup.md) - setup an Ubuntu virtual machine you can use for testing, and quickly restore to known-good states

--- a/tooling/computer-setup.md
+++ b/tooling/computer-setup.md
@@ -1,0 +1,51 @@
+# Computer Setup
+This guide walks you through your options to keep work and personal content separate. There are a variety of reasons to keep your work and personal computing domains separate. Legal reasons include being asked to erase ENF intellectual property or being subpoenaed for work content. Practical reasons include protecting yourself from personal content inadvertently being shared on video calls, or being able to "disconnect" from work in your free time.
+
+### Options
+You have three primary options.
+1. [Multiple Computers](#multiple-computers)
+1. [Virtual Machines](#virtual-machines)
+1. [User Accounts](#user-accounts)
+
+## Multiple Computers
+This is the most straightforward, but most expensive, option. You have one or more computers for personal use, and one or more computers for work use that are physically distinct. This is simple to implement and very secure.
+
+## Virtual Machines
+You can also use a virtual machine for work. This is cheaper than having multiple physical computers, is almost as secure, and is more convenient. However, you won't be able to use all of your computer's resources for work tasks such as compiling code.
+
+Check out the [virtual machine setup guide](./vm-setup.md) for more information on this.
+
+## User Accounts
+You can have a work user account and a personal user account on the same physical computer. This is somewhat less secure than the other options because developers and engineers will need their work account to have administrator or super user permissions to do their job. However, this option is great because it allows you to use all the resources on your computer for work, makes it easy to switch back and forth, allows you to use your existing machines, enables you to work on _any_ machine you own, and provides a sufficient degree of separation.
+
+### LightDM
+These instructions are written for Linux Mint (Debian-base), but should work for any Linux distribution using [LightDM](https://wiki.archlinux.org/title/LightDM) as the display manager.
+
+This guide will walk you through provisioning a separate user account for work, then logging into both _simultaneously_. Your personal account will exist on TTY7 (`[Ctrl] + [Alt] + [F7]`), and your work account will exist on TTY8 (`[Ctrl] + [Alt] + [F8]`). You can be logged into only one or the other, both simultaneously, have one or both locked, switch back and forth instantaneously, and run apps in both at the same time while still keeping them decently isolated. Programs running under either account will have access to their share of the entire computer's physical resources.
+
+1. Create a new user account in Linux that will show up on the login screen. Be sure to replace `$username` with the desired username. The author uses `zach` as his personal username, and chose `zach-enf` as his work username.
+    ```bash
+    # create a new user account with home folders, default shell, and default password
+    sudo useradd -m -p "$(perl -e 'print crypt("password", "salt")')" -s /bin/bash $username  # crypt(password, salt)
+    # force the user to reset their password on next login
+    sudo chage -d 0 username
+    ```
+1. Give the new user sudo permissions. This step is **_optional_**, but engineers will likely need this. You may consider doing this _after_ logging in for the first time and chaging your password.
+    ```bash
+    sudo usermod -a -G sudo $username
+    ```
+1. Start a new LightDM session.
+    ```bash
+    dm-tool switch-to-greeter
+    ```
+    This will drop you in a new LightDM session on TTY8 with a login screen.
+1. Login using the password you created in step 1. Linux should promt you to immediately change your password.
+1. Change desktop background, layout, and color scheme to make it visually distinctive from your personal account.
+    - For example, if you use a green desktop background and iconography in your personal account, consider a blue desktop background and iconography in your work account so you can immediately tell which user you are on.
+
+At this point, your personal account will exist at `[Ctrl] + [Alt] + [F7]` (TTY7), and your work account will exist at `[Ctrl] + [Alt] + [F8]` (TTY8). Try it.
+
+When you boot your computer, you will be on TTY7 by default (`[Ctrl] + [Alt] + [F7]`). Whatever account you login to here will be on TTY7. To log into the other user simultaneously, you will have to run the command from before to start a second LightDM session on TTY8.
+```bash
+dm-tool switch-to-greeter
+```

--- a/tooling/computer-setup.md
+++ b/tooling/computer-setup.md
@@ -41,7 +41,7 @@ This guide will walk you through provisioning a separate user account for work, 
     dm-tool switch-to-greeter
     ```
     This will drop you in a new LightDM session on TTY8 with a login screen.
-1. Login using the password you created in step 1. Linux should promt you to immediately change your password. If it doesn't, immediately change your password! See the warning above.
+1. Login using the password you created in step 1. Linux should prompt you to immediately change your password. If it doesn't, immediately change your password! See the warning above.
     - If you copied and pasted the command in step 1 verbatim, the password for your first login will be `Password1`.
 1. Change desktop background, layout, and color scheme to make it visually distinctive from your personal account.
     - For example, if you use a green desktop background and iconography in your personal account, consider a blue desktop background and iconography in your work account so you can immediately tell which user you are on.

--- a/tooling/computer-setup.md
+++ b/tooling/computer-setup.md
@@ -30,6 +30,8 @@ This guide will walk you through provisioning a separate user account for work, 
     # force the user to reset their password on next login
     sudo chage -d 0 username
     ```
+    - ⚠️ **Warning** ⚠️  
+      DO NOT use the password you set here beyond logging in to the new user account for the first time (step 4 below)! The `perl` `crypt()` command uses [DES](https://en.wikipedia.org/wiki/Data_Encryption_Standard) to hash your password, a _50 year old_ algorithm [broken in 1998 by the Electronic Frontier Foundation](https://en.wikipedia.org/wiki/EFF_DES_cracker). It would be trivial for anyone who legitimately or illegitimately gains access to any account on your computer to obtain this password. The time, expense, and difficulty to break this is essentially zero. When you log into the new user account for the first time and change your password, Linux will use a secure, modern algorithm to protect it. For example, Linux Mint uses SHA-512 designed by the NSA, ratified by NIST, and which has no known practical attacks.
 1. Give the new user sudo permissions. This step is **_optional_**, but engineers will likely need this. You may consider doing this _after_ logging in for the first time and chaging your password.
     ```bash
     sudo usermod -a -G sudo $username
@@ -39,7 +41,7 @@ This guide will walk you through provisioning a separate user account for work, 
     dm-tool switch-to-greeter
     ```
     This will drop you in a new LightDM session on TTY8 with a login screen.
-1. Login using the password you created in step 1. Linux should promt you to immediately change your password.
+1. Login using the password you created in step 1. Linux should promt you to immediately change your password. If it doesn't, immediately change your password! See the warning above.
 1. Change desktop background, layout, and color scheme to make it visually distinctive from your personal account.
     - For example, if you use a green desktop background and iconography in your personal account, consider a blue desktop background and iconography in your work account so you can immediately tell which user you are on.
 

--- a/tooling/computer-setup.md
+++ b/tooling/computer-setup.md
@@ -52,5 +52,6 @@ When you boot your computer, you will be on TTY7 by default (`[Ctrl] + [Alt] + [
 ```bash
 dm-tool switch-to-greeter
 ```
+You will only have to run this command once after each time you reboot.
 
 Once you have a working solution for your work stuff, head to the [tool install guide](./tool-install-guide.md).

--- a/tooling/computer-setup.md
+++ b/tooling/computer-setup.md
@@ -26,7 +26,7 @@ This guide will walk you through provisioning a separate user account for work, 
 1. Create a new user account in Linux that will show up on the login screen. Be sure to replace `$username` with the desired username. The author uses `zach` as his personal username, and chose `zach-enf` as his work username.
     ```bash
     # create a new user account with home folders, default shell, and default password
-    sudo useradd -m -p "$(perl -e 'print crypt("password", "salt")')" -s /bin/bash $username  # crypt(password, salt)
+    sudo useradd -m -p "$(perl -e 'print crypt("Password1", "salt")')" -s /bin/bash $username  # crypt(password, salt)
     # force the user to reset their password on next login
     sudo chage -d 0 username
     ```
@@ -42,6 +42,7 @@ This guide will walk you through provisioning a separate user account for work, 
     ```
     This will drop you in a new LightDM session on TTY8 with a login screen.
 1. Login using the password you created in step 1. Linux should promt you to immediately change your password. If it doesn't, immediately change your password! See the warning above.
+    - If you copied and pasted the command in step 1 verbatim, the password for your first login will be `Password1`.
 1. Change desktop background, layout, and color scheme to make it visually distinctive from your personal account.
     - For example, if you use a green desktop background and iconography in your personal account, consider a blue desktop background and iconography in your work account so you can immediately tell which user you are on.
 

--- a/tooling/computer-setup.md
+++ b/tooling/computer-setup.md
@@ -32,7 +32,7 @@ This guide will walk you through provisioning a separate user account for work, 
     ```
     - ⚠️ **Warning** ⚠️  
       DO NOT use the password you set here beyond logging in to the new user account for the first time (step 4 below)! The `perl` `crypt()` command uses [DES](https://en.wikipedia.org/wiki/Data_Encryption_Standard) to hash your password, a _50 year old_ algorithm [broken in 1998 by the Electronic Frontier Foundation](https://en.wikipedia.org/wiki/EFF_DES_cracker). It would be trivial for anyone who legitimately or illegitimately gains access to any account on your computer to obtain this password. The time, expense, and difficulty to break this is essentially zero. When you log into the new user account for the first time and change your password, Linux will use a secure, modern algorithm to protect it. For example, Linux Mint uses SHA-512 designed by the NSA, ratified by NIST, and which has no known practical attacks.
-1. Give the new user sudo permissions. This step is **_optional_**, but engineers will likely need this. You may consider doing this _after_ logging in for the first time and chaging your password.
+1. Give the new user sudo permissions. This step is **_optional_**, but engineers will likely need this. You may consider doing this _after_ logging in for the first time and chaging your password. This will have to be done from your existing (personal) user account, not the new one.
     ```bash
     sudo usermod -a -G sudo $username
     ```

--- a/tooling/computer-setup.md
+++ b/tooling/computer-setup.md
@@ -49,3 +49,5 @@ When you boot your computer, you will be on TTY7 by default (`[Ctrl] + [Alt] + [
 ```bash
 dm-tool switch-to-greeter
 ```
+
+Once you have a working solution for your work stuff, head to the [tool install guide](./tool-install-guide.md).

--- a/tooling/computer-setup.md
+++ b/tooling/computer-setup.md
@@ -46,7 +46,7 @@ This guide will walk you through provisioning a separate user account for work, 
 1. Change desktop background, layout, and color scheme to make it visually distinctive from your personal account.
     - For example, if you use a green desktop background and iconography in your personal account, consider a blue desktop background and iconography in your work account so you can immediately tell which user you are on.
 
-At this point, your personal account will exist at `[Ctrl] + [Alt] + [F7]` (TTY7), and your work account will exist at `[Ctrl] + [Alt] + [F8]` (TTY8). Try it.
+At this point, your personal account will exist at TTY7 (`[Ctrl] + [Alt] + [F7]`), and your work account will exist at TTY8 (`[Ctrl] + [Alt] + [F8]`). Try it.
 
 When you boot your computer, you will be on TTY7 by default (`[Ctrl] + [Alt] + [F7]`). Whatever account you login to here will be on TTY7. To log into the other user simultaneously, you will have to run the command from before to start a second LightDM session on TTY8.
 ```bash

--- a/tooling/computer-setup.md
+++ b/tooling/computer-setup.md
@@ -19,7 +19,7 @@ Check out the [virtual machine setup guide](./vm-setup.md) for more information 
 You can have a work user account and a personal user account on the same physical computer. This is somewhat less secure than the other options because developers and engineers will need their work account to have administrator or super user permissions to do their job. However, this option is great because it allows you to use all the resources on your computer for work, makes it easy to switch back and forth, allows you to use your existing machines, enables you to work on _any_ machine you own, and provides a sufficient degree of separation.
 
 ### LightDM
-These instructions are written for Linux Mint (Debian-base), but should work for any Linux distribution using [LightDM](https://wiki.archlinux.org/title/LightDM) as the display manager.
+These instructions are written for Linux Mint (Debian-family, Ubunut-based), but should work for any Linux distribution using [LightDM](https://wiki.archlinux.org/title/LightDM) as the display manager.
 
 This guide will walk you through provisioning a separate user account for work, then logging into both _simultaneously_. Your personal account will exist on TTY7 (`[Ctrl] + [Alt] + [F7]`), and your work account will exist on TTY8 (`[Ctrl] + [Alt] + [F8]`). You can be logged into only one or the other, both simultaneously, have one or both locked, switch back and forth instantaneously, and run apps in both at the same time while still keeping them decently isolated. Programs running under either account will have access to their share of the entire computer's physical resources.
 

--- a/tooling/tool-install-guide.md
+++ b/tooling/tool-install-guide.md
@@ -1,0 +1,263 @@
+# Tool Install Guide
+This guide will walk you through installing common engineering tools on your system. If you haven't read the [computer setup](./computer-setup.md) guide yet, start there. This guide is written for Ubuntu derivatives using the BASH shell.
+
+1. Update your system.
+    ```bash
+    sudo apt-get update
+    sudo apt-get upgrade -y
+    sudo apt-get autoremove
+    ```
+1. [Terminator](https://gnome-terminator.org) - iTerm2-like terminal emulator for Linux
+    ```bash
+    sudo apt-get install -y terminator
+    ```
+    1. Check `Terminator` > right-click > `Preferences` > `Profiles` > `Scrolling` > `Infinite Scrollback`.
+    1. I like to invert the titlebar colors so "focused" is blue (`#0076C9`) or green (`#3FBC6C`), and "receiving" is red (`#C80003`). It is just less aggressive and more plesant to look at. These settings are in `Terminator` > right-click > `Preferences` > `General` > `Terminal Titlebar`.
+1. [Vim](https://www.vim.org) - CLI text editor and related utilities
+    ```bash
+    sudo apt-get install -y vim vim-common
+    ```
+1. [VScode](https://code.visualstudio.com) - GUI text editor
+    ```bash
+    sudo apt-get install -y vim vim-common
+    ```
+1. [Zap](https://github.com/srevinsaju/zap) - a package manager for `*.AppImage` programs
+    ```bash
+    sudo wget https://github.com/srevinsaju/zap/releases/download/continuous/zap-amd64 -O /usr/local/bin/zap
+    sudo chmod +x /usr/local/bin/zap
+    ```
+1. [Bitwarden](https://bitwarden.com) - secure, open-source password manager
+    ```bash
+    curl -fSL 'https://vault.bitwarden.com/download/?app=desktop&platform=linux&variant=appimage' -o ~/Downloads/Bitwarden.AppImage
+    zap install bitwarden ~/Downloads/Bitwarden.AppImage
+    ```
+    Fix missing logo.
+    ```bash
+    sed -E "s_(Icon=).*$$_\1/home/$USERNAME/.local/share/zap/v2/icons/bitwarden.png_" -i ~/.local/share/applications/bitwarden.desktop
+    ```
+1. [Joplin](https://joplinapp.org) - open-source, Evernote-like note taking app
+    ```bash
+    zap install --from 'https://github.com/laurent22/joplin/releases/download/v2.8.8/Joplin-2.8.8.AppImage' joplin
+    ```
+    Fix missing logo.
+    ```bash
+    sed -E "s_(Icon=).*$$_\1/home/$USERNAME/.local/share/zap/v2/icons/joplin.png_" -i ~/.local/share/applications/joplin.desktop
+    ```
+1. [Telegram Desktop](https://desktop.telegram.org) - psuedo-secure instant messaging application
+    ```bash
+    sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+    flatpak install flathub org.telegram.desktop
+    ```
+    Log into and configure Telegram Desktop.
+1. [Brave](https://brave.com) - privacy-focused Chromium-based web browser with builtin ad and tracker blocking
+    ```bash
+    sudo apt-get install -y apt-transport-https curl
+    sudo curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
+    ```
+    Configure Brave, including logging into or creating a work sync profile, if you wish.
+1. [Firefox](https://www.mozilla.org/en-US/firefox/new) - a privacy-focused web browser not built on software from an advertisement juggernaut
+    ```bash
+    sudo apt-get install -y firefox
+    ```
+    Configure Firefox, including logging into or creating a work Mozilla account, if you wish.
+1. [pip](https://pypi.org/project/pip) - package manager for Python
+    ```bash
+    sudo apt-get install -y python3-pip python3-venv
+    ```
+1. [docker](https://www.docker.com) - container engine, like virtual machines but lighter
+    ```bash
+    sudo apt-get install -y ca-certificates curl gnupg lsb-release
+    sudo mkdir -p /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o ~/Downloads/docker.gpg
+    cat ~/Downloads/docker.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    # note: this command will only work on Ubuntu and Ubuntu derivatives
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(source /etc/upstream-release/lsb-release 2>/dev/null && echo "$DISTRIB_CODENAME" || lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list
+    sudo apt-get update
+    sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    sudo service docker start
+    sudo docker run hello-world
+    ```
+    1. Download Ubuntu docker images.
+        ```bash
+        docker pull ubuntu:18.04
+        docker pull ubuntu:20.04
+        docker pull ubuntu:22.04
+        ```
+1. [VirtualBox](https://www.virtualbox.org) - type 2 hypervisor for running computers inside computers as a program
+    ```bash
+    sudo apt-get install -y virtualbox
+    ```
+1. [qBittorrent](https://www.qbittorrent.org) - open-source bittorrent client
+    1. Optionally, install [this](https://gitlab.com/qbittorrent-black-theme/client) OLED-dark theme.
+    1. Download [Ubuntu `*.iso` images](https://ubuntu.com/download/alternative-downloads) for VirtualBox.
+1. [Caffeine](https://launchpad.net/caffeine) - keep your computer awake
+    ```bash
+    sudo apt-get install -y caffeine
+    ```
+    Make the caffeine indicator appear in the system tray on startup.
+    ```bash
+    ln -s /usr/share/applications/caffeine-indicator.desktop ~/.config/autostart/caffeine-indicator.desktop
+    ```
+1. [git](https://git-scm.com) - open-source, distributed version control software
+    ```bash
+    sudo apt-get install -y git
+    ```
+    1. Install git.
+        ```bash
+        brew install git
+        ```
+    1. Generate an SSH Key and associate it with your GitHub account.
+        1. Generate an ed25519 SSH key using your work email.
+            ```bash
+            ssh-keygen -t ed25519 -f ~/.ssh/github.key -C first.last@eosnetwork.com
+            ```
+        1. Enter a [strong passphrase](https://www.eff.org/dice).
+            - Convenient local JavaScript [diceware generator](https://www.rempe.us/diceware/#eff), trust at your own risk. We recommend using Bitwarden to generate the password or passphrase.
+        1. Check that SSH daemon is running
+            ```bash
+            ssh-agent -s 1>/dev/null && echo 'SSH daemon is running' || echo 'SSH daemon is not running'
+            ```
+        1. Add new key to keystore.
+            ```bash
+            ssh-add ~/.ssh/github.key
+            ```
+        1. Copy your public key to clipboard.
+            ```bash
+            cat ~/.ssh/github.key.pub
+            ```
+        1. In your browser, go to:
+           [GitHub](https://github.com/) > [Settings](https://github.com/settings/profile) > [SSH and GPG keys](https://github.com/settings/keys) > [New SSH key](https://github.com/settings/ssh/new)
+        1. Paste your public key into `Key`.
+        1. Give your SSH key a meaningful title, for example "ENF" followed by your computer hostname.
+        1. Click `Add SSH Key`.
+        1. Test it.
+            1. Connect to GitHub via SSH.
+                ```bash
+                ssh -T git@github.com
+                ```
+            1. Accept the GitHub RSA fingerprint.
+                ```
+                yes
+                ```
+            1. You should see:
+                ```
+                You've successfully authenticated, but GitHub does not provide shell access.
+                ```
+    1. Generate an ed25519 GPG Key and associate it with your GitHub account.
+        1. Generate the key using your work email.
+            1. Start GPG.
+                ```bash
+                gpg --expert --full-generate-key
+                ```
+            1. Select `ECC (Sign Only)`.  
+               `10`, `[Enter]`
+            1. Use an ed25519 key.  
+               `1`, `[Enter]`
+            1. Set your desired key expiration period.  
+               `0`, `[Enter]`  
+               `y`, `[Enter]`
+            1. Enter your name as you want it to appear next to your contributions in our open-source commit history.
+            1. Enter either your work email address, or your [GitHub no-reply email address](https://help.github.com/en/articles/setting-your-commit-email-address).
+                - This email address MUST match one of the emails attached to your GitHub account.
+            1. Enter your computer's hostname for the comment.
+            1. Confirm the settings.  
+               `o` (letter 'o' key)
+            1. Enter a [strong passphrase](https://www.eff.org/dice), twice.
+                - Convenient local JavaScript [diceware generator](https://www.rempe.us/diceware/#eff), trust at your own risk. We recommend using Bitwarden to generate the password or passphrase.
+        1. Associate your GPG key with your GitHub account.
+            1. Copy your public key to the clipboard.
+                ```bash
+                gpg --armor --export "$(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}' | cut -d '/' -f '2')"
+                ```
+            1. In your browser, go to:
+               [GitHub](https://github.com/) > [Settings](https://github.com/settings/profile) > [SSH and GPG keys](https://github.com/settings/keys) > [New GPG key](https://github.com/settings/gpg/new)
+            1. Paste your public key into `Key`.
+            1. Click `Add GPG Key`.
+    1. Configure your shell.
+        1. Configure `gpg` to use `gpg-agent`, similar to `ssh-agent`.
+            ```bash
+            echo 'use-agent' > ~/.gnupg/gpg.conf
+            ```
+        1. Configure `gpg-agent` to use the keychain to store the GPG passphrase.
+            ```bash
+            echo 'pinentry-program /usr/bin/pinentry-gnome3' > ~/.gnupg/gpg-agent.conf
+            ```
+        1. Reload the `gpg-agent` daemon with the new settings.
+            ```bash
+            echo RELOADAGENT | gpg-connect-agent
+            ```
+        1. Load your keys in all shells.
+            ```bash
+            cat << 'BASH' >> ~/.bashrc
+            ### GitHub ###
+            export GPG_TTY=$(tty)
+
+            BASH
+            source ~/.bashrc
+            ```
+    1. Store your GPG passphrase in the keyring.
+        1. Invoke a `pinentry-gnome3` password prompt.
+            ```bash
+            echo '1234' | gpg -o /dev/null --local-user "$(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}' | cut -d '/' -f '2')" -as - && echo 'Looks good! Can we sign code next time?' || echo 'Oh noes! We could not authenticate!'
+            ```
+        1. Check `Save in Keychain`.
+        1. Enter your GPG passphrase created earlier.
+        1. Click `OK`.
+    1. Configure git.
+        1. Add your work email address.
+            ```bash
+            git config --global user.email first.last@eosnetwork.com
+            ```
+        1. Add your real name.
+            ```bash
+            git config --global user.name 'First Last'
+            ```
+        1. Point git to your GPG key.
+            ```bash
+            git config --global user.signingkey "$(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}' | cut -d '/' -f '2')"
+            ```
+        1. Configure git to sign all commits pushed from this user account on this computer.
+            ```bash
+            git config --global commit.gpgsign true
+            ```
+        1. Configure git to use your preferred editor.
+            ```bash
+            git config --global core.editor 'vim'
+            ```
+        1. Configure git to use SSH for all submodules, even if the repo defines them with HTTPS.
+            ```
+            cat << 'BASH' >> ~/.gitconfig
+            [url "ssh://git@github.com/"]
+                    insteadOf = https://github.com/
+            BASH
+            ```
+    1. Verify that your work email is associated with your GitHub account.
+       [GitHub](https://github.com/) > [Settings](https://github.com/settings/profile) > [Emails](https://github.com/settings/emails)
+        - If your work email is not associated with your GitHub account, your activity on GitHub (pull requests, issues, comments) will appear to come from a different account than your commits and pushes made from this device.
+        - Performing this association later can retroactively associate commits with your account.
+1. [Beyond Compare](https://www.scootersoftware.com/features.php) - side-by-side comparison, editing, and merging of text, hex, binaries, Office documents, pictures, MP3s, archives, and folders; with support for git integration and cloud locations such as FTP, SFTP, Dropbox, or buckets
+    1. Install Beyond Compare.
+        ```bash
+        sudo apt-get install -y bcompare
+        ```
+    1. Configure git for diffs with Beyond Compare.
+        ```bash
+        git config --global diff.tool bc3
+        git config --global difftool.bc3.trustExitCode true
+        ```
+            - The behavior of `git diff` cannot be changed, you use `git difftool` to diff with Beyond Compare.
+    1. Configure git for resolving merge conflicts with Beyond Compare.
+        ```bash
+        git config --global merge.tool bc3
+        git config --global mergetool.bc3.trustExitCode true
+        ```
+            - Invoke `git mergetool` when you want to use Beyond Compare to resolve merge conflicts.
+
+1. [git-imerge](https://github.com/mhagger/git-imerge) - branch merge conflict resolution tool
+    ```bash
+    pip install git-imerge
+    ```
+1. Make a work directory.
+    ```bash
+    mkdir -p ~/Work
+    ```

--- a/tooling/tool-install-guide.md
+++ b/tooling/tool-install-guide.md
@@ -19,7 +19,7 @@ This guide will walk you through installing common engineering tools on your sys
     ```
 1. [VScode](https://code.visualstudio.com) - GUI text editor
     ```bash
-    sudo apt-get install -y vim vim-common
+    sudo apt-get install -y code
     ```
 1. [Zap](https://github.com/srevinsaju/zap) - a package manager for `*.AppImage` programs
     ```bash

--- a/tooling/tool-install-guide.md
+++ b/tooling/tool-install-guide.md
@@ -21,6 +21,8 @@ This guide will walk you through installing common engineering tools on your sys
     ```bash
     sudo apt-get install -y code
     ```
+    1. [GitLens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens) - VScode extension to view files in the context of their `git` history
+    1. [Dark+ Pure Black (OLED)](https://marketplace.visualstudio.com/items?itemName=ChadBaileyVh.oled-pure-black---vscode) - _Optional_ extension to make the existing Dark+ theme distributed with VScode use true black, for OLED displays
 1. [Zap](https://github.com/srevinsaju/zap) - a package manager for `*.AppImage` programs
     ```bash
     sudo wget https://github.com/srevinsaju/zap/releases/download/continuous/zap-amd64 -O /usr/local/bin/zap


### PR DESCRIPTION
This pull request introduces two guides based on my personal notes. The first explains options for separating your work and personal digital life. This includes instructions for Linux users using LightDM to setup a system where their personal stuff is on TTY7 and their work stuff is on TTY8 simultaneously. The second is a tool install guide. I think it can be organized better and is certainly missing some core tools to build Leap, but I want to get this up before the meeting Thursday to discuss onboarding resources.

Unfortunately, these instructions are only for Debian-family Ubuntu derivatives such as Ubuntu or Mint. MacOS instructions aren't much different and I could come up with them given more time, but I'm not sure how to organize it. Sub-bullets for each OS family? Idk.