### PR TITLE
Fix Hyperlinks in Root README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Engineering
 This repository contains documentation managed by the ENF Engineering team. The documentation is primary focused on development processes followed by and tooling used by our team, which may be valuable to outside contributors who wish to contribute to the codebases managed by the ENF.
 
-If you are new here, start with the [computer setup guide](./computer-setup.md), then the [tool install guide](./tool-install-guide.md).
+If you are new here, start with the [computer setup guide](./tooling/computer-setup.md), then the [tool install guide](./tooling/tool-install-guide.md).
 
 ### Index
 1. [Process](./process/) - development processes


### PR DESCRIPTION
The hyperlinks I introduced to the root `README.md` for [issue 8](https://github.com/eosnetworkfoundation/engineering/issues/8) are broken. Fix.