### PR TITLE
Support Using the GPG Key for Commit Signing for PGP Messages

### DIFF
--- a/tooling/tool-install-guide.md
+++ b/tooling/tool-install-guide.md
@@ -151,8 +151,8 @@ This guide will walk you through installing common engineering tools on your sys
                 ```bash
                 gpg --expert --full-generate-key
                 ```
-            1. Select `ECC (Sign Only)`.  
-               `10`, `[Enter]`
+            1. Select `ECC and ECC`.  
+               `9`, `[Enter]`
             1. Use an ed25519 key.  
                `1`, `[Enter]`
             1. Set your desired key expiration period.  


### PR DESCRIPTION
The `git` commit signing instructions were referenced in a video call today, so I want to fix the step where you choose your key type to include ECC encryption. This enables someone to use the key(s) at `https://github.com/$USERNAME.gpg` to send PGP messages. This has already been used in the ENF to securely share secrets.